### PR TITLE
Constraints and some unary functions added to parser

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -1,9 +1,17 @@
-### My lil draft of the formal syntax for *regressions*
+### My lil draft of the formal syntax for *rat*
 
-We are going to follow stan's grammar, but alot of stuff stripped out
+We are going to follow stan's [grammar](https://mc-stan.org/docs/2_18/reference-manual/bnf-grammars.html), but alot of stuff stripped out 
 
+1. Scanner
+    - Input: a string
+    - Output: a list of Tokens
+2. Parser
+    - Input: a list of Tokens
+    - Output: an expression tree
+3. Compiler
+    - Input: a list of expression trees
+    - Output: a python function representing the model
 #### Tokens
-
 1. `Identifier` Any variable/function/distribution/data
 2. `RealLiteral` Real constant
 3. `IntLiteral` Integer constant
@@ -14,11 +22,24 @@ We are going to follow stan's grammar, but alot of stuff stripped out
     - expression lists(called `expressions`) `","`
     - Indexing `"[", "]"`
     - Sampling `"~"`
+
+##### Note on `<` and `>`
+ You can see that angled brackets can mean `greater than` or `less than` when interpreted as operators,
+but a complete set of them(`<lower=...>`) also represent the constraint region when in the left hand side of a
+statement. In the scanner, which does not take into account semantics, they are just classified as an `Operator`
+token. 
+
+This means the parser will fail when evaluating constraints in a standard ll(k) approach because it will attempt 
+to try and evaluate a non-existant rhs expression for the `>` operator. Therefore, the one and only artificial modification 
+I have made to the parser when evaluating constraints is to identify the angled brackets, and convert then from 
+`Operator` to `Special` tokens, which makes the parser recognize them as delimiters instead of operators.   
+
 #### BNF
 
 ```
 
 expressions ::= expression % ','
+             | lag(expression, expression) % ','
 expression ::= expression infixOps expression
              | prefixOp expression
              | identifier '[' expressions ']'
@@ -32,12 +53,21 @@ infixOps ::= ("+", "-", "*", "/", "%",
 
 prefixOps ::= ("!", "-")
 
+unaryFunction ::= ("exp", "abs", "floor", "ceil", "round")
+
 ; didn't implement control flow yet
 statement ::= atomic_statement
 
+; constraints
+constraint ::= ?('<' constraint_range '>')
+
+constraint_range ::= 'lower' '=' expressioni ',' 'upper' = expressoin
+        | 'lower' '=' expression
+        | 'upper' '=' expression
+
 Distribution ::= ("normal")
 
-lhs ::= identifier ('[' expressions ']')*
+lhs ::= identifier constraint ('[' expressions ']')*
 assignmentOp ::= ("=", "+=", "-=", "*=", "/=")
 
 ; statements, assume assignments are allowed

--- a/rat/ops.py
+++ b/rat/ops.py
@@ -89,7 +89,7 @@ class Param(Expr):
             return self.code_name()
 
     def __str__(self):
-        return f"Param({self.name}, {self.index.__str__()})"
+        return f"Param({self.name}, {self.index.__str__()}, lower={self.lower}, upper={self.upper})"
         # return f"Placeholder({self.name}, {self.index.__str__()}) = {{{self.value.__str__()}}}"
 
 
@@ -180,6 +180,21 @@ class Mul(Expr):
 
     def __str__(self):
         return f"Mul({self.left.__str__()}, {self.right.__str__()})"
+
+
+@dataclass(frozen=True)
+class Pow(Expr):
+    left: Expr
+    right: Expr
+
+    def __iter__(self):
+        return iter([self.left, self.right])
+
+    def code(self):
+        return f"{self.left.code()} ^ {self.right.code()}"
+
+    def __str__(self):
+        return f"Pow({self.left.__str__()}, {self.right.__str__()})"
 
 
 @dataclass(frozen=True)
@@ -434,6 +449,75 @@ class DivAssignment(Expr):
     def __str__(self):
         return f"DivAssignment({self.lhs.__str__()}, {self.rhs.__str__()})"
 
+
+@dataclass(frozen=True)
+class Exp(Expr):
+    subexpr: Expr
+
+    def __iter__(self):
+        return iter([self.subexpr])
+
+    def code(self):
+        return f"exp({self.subexpr.code()})"
+
+    def __str__(self):
+        return f"Exp({self.subexpr.__str__()})"
+
+
+@dataclass(frozen=True)
+class Abs(Expr):
+    subexpr: Expr
+
+    def __iter__(self):
+        return iter([self.subexpr])
+
+    def code(self):
+        return f"abs({self.subexpr.code()})"
+
+    def __str__(self):
+        return f"Abs({self.subexpr.__str__()})"
+
+
+@dataclass(frozen=True)
+class Floor(Expr):
+    subexpr: Expr
+
+    def __iter__(self):
+        return iter([self.subexpr])
+
+    def code(self):
+        return f"floor({self.subexpr.code()})"
+
+    def __str__(self):
+        return f"Floor({self.subexpr.__str__()})"
+
+
+@dataclass(frozen=True)
+class Ceil(Expr):
+    subexpr: Expr
+
+    def __iter__(self):
+        return iter([self.subexpr])
+
+    def code(self):
+        return f"ceil({self.subexpr.code()})"
+
+    def __str__(self):
+        return f"Ceil({self.subexpr.__str__()})"
+
+
+@dataclass(frozen=True)
+class Round(Expr):
+    subexpr: Expr
+
+    def __iter__(self):
+        return iter([self.subexpr])
+
+    def code(self):
+        return f"round({self.subexpr.code()})"
+
+    def __str__(self):
+        return f"Round({self.subexpr.__str__()})"
 
 @dataclass
 class Placeholder(Expr):

--- a/rat/ops.py
+++ b/rat/ops.py
@@ -519,6 +519,7 @@ class Round(Expr):
     def __str__(self):
         return f"Round({self.subexpr.__str__()})"
 
+
 @dataclass
 class Placeholder(Expr):
     name: str

--- a/rat/parser.py
+++ b/rat/parser.py
@@ -257,18 +257,16 @@ class Parser:
                                 n_openbrackets += 1
                             if self.peek(idx).value == ">":
                                 if n_openbrackets == 0:
-                                    self.tokens[idx] = Special(
-                                        ">"
-                                    )  # switch from Operator to Special
+                                    # switch from Operator to Special
+                                    self.tokens[idx] = Special(">")
                                     break
                                 else:
                                     n_openbrackets -= 1
                         # now actually parse the constraints
                         lower = RealConstant(float("-inf"))
                         upper = RealConstant(float("inf"))
-                        for _ in range(
-                            2
-                        ):  # loop at max 2 times, once for lower, once for upper
+                        for _ in range(2):
+                            # loop at max 2 times, once for lower, once for upper
                             if lookahead_2.value == "lower":
                                 self.remove()  # "lower"
                                 self.expect_token(Operator, token_value="=")
@@ -280,12 +278,10 @@ class Parser:
                                 self.remove()  # =
                                 upper = self.expression()
 
-                            lookahead_1 = (
-                                self.peek()
-                            )  # can be either ",", which means loop again, or ">", which breaks
-                            lookahead_2 = self.peek(
-                                1
-                            )  # either "lower", or "upper" if lookahead_1 == ","
+                            lookahead_1 = self.peek()
+                            # can be either ",", which means loop again, or ">", which breaks
+                            lookahead_2 = self.peek(1)
+                            # either "lower", or "upper" if lookahead_1 == ","
                             if lookahead_1.value == ",":
                                 self.remove()  # ,
                             elif lookahead_1.value == ">":
@@ -297,7 +293,8 @@ class Parser:
                                 )
 
                         # the for loop takes of the portion "<lower= ... >
-                        # this means the constraint part of been processed and removed from the token queue at this point
+                        # this means the constraint part of been processed and
+                        # removed from the token queue at this point
                         exp.lower = lower
                         exp.upper = upper
 
@@ -315,12 +312,10 @@ class Parser:
             self.remove()  # )
             exp = next_expression  # expression
 
-        next_token = (
-            self.peek()
-        )  # this is for the following 2 rules, which have conditions after expression
-        if (
-            isinstance(next_token, Special) and next_token.value == "["
-        ):  # identifier '[' expressions ']'
+        next_token = self.peek()
+        # this is for the following 2 rules, which have conditions after expression
+        if isinstance(next_token, Special) and next_token.value == "[":
+            # identifier '[' expressions ']'
             self.remove()  # [
             warnings.warn(
                 "Parser: Indices are assumed to be a single literal, not expression."
@@ -357,9 +352,8 @@ class Parser:
                 rhs = self.expression()
                 return AssignmentOps.generate(lhs, op, rhs)
 
-            elif (
-                isinstance(op, Special) and op.value == "~"
-            ):  # distribution declaration
+            elif isinstance(op, Special) and op.value == "~":
+                # distribution declaration
                 self.expect_token(Special, "~")
                 self.remove()  # ~
                 distribution = self.peek()

--- a/rat/parser.py
+++ b/rat/parser.py
@@ -1,16 +1,7 @@
 from typing import *
-import warnings
-
-from .scanner import (
-    Token,
-    Identifier,
-    Operator,
-    RealLiteral,
-    IntLiteral,
-    Special,
-    NullToken,
-)
+from .scanner import Token, Identifier, Operator, RealLiteral, IntLiteral, Special, NullToken
 from .ops import *
+import warnings
 
 # https://mc-stan.org/docs/2_18/reference-manual/bnf-grammars.html
 # https://mc-stan.org/docs/2_28/reference-manual/arithmetic-expressions.html
@@ -45,7 +36,7 @@ class PostfixOps:  # not used atm
 
 
 class InfixOps:
-    ops = ["+", "-", "*", "/", "%", "||", "&&", "==", "!=", "<", "<=", ">", ">="]
+    ops = ["+", "-", "*", "^", "/", "%", "||", "&&", "==", "!=", "<", "<=", ">", ">="]
 
     @staticmethod
     def check(tok: Type[Token]):
@@ -61,6 +52,8 @@ class InfixOps:
             return Diff(lhs, rhs)
         elif token.value == "*":
             return Mul(lhs, rhs)
+        elif token.value == "^":
+            return Pow(lhs, rhs)
         elif token.value == "%":
             return Mod(lhs, rhs)
         elif token.value == "||":
@@ -81,7 +74,6 @@ class InfixOps:
             return GreaterThanOrEqual(lhs, rhs)
         else:
             raise Exception(f"InfixOps: Unknown operator type {token.value}")
-
 
 # group parsing rules for statements
 
@@ -109,18 +101,27 @@ class AssignmentOps:
             return DivAssignment(lhs, rhs)
 
 
-class DefaultFunctions:
+class UnaryFunctions:
     names = ["exp", "abs", "floor", "ceil", "round"]
 
     @staticmethod
     def check(tok: Type[Token]):
-        if isinstance(tok, Identifier) and tok.value in DefaultFunctions.names:
+        if isinstance(tok, Identifier) and tok.value in UnaryFunctions.names:
             return True
         return False
 
     @staticmethod
-    def generate(subexpr: Expr, tok: Identifier):
-        pass
+    def generate(subexpr: Expr, func_type: Identifier):
+        if func_type.value == "exp":
+            return Exp(subexpr)
+        elif func_type.value == "abs":
+            return Abs(subexpr)
+        elif func_type.value == "floor":
+            return Floor(subexpr)
+        elif func_type.value == "ceil":
+            return Ceil(subexpr)
+        elif func_type.value == "round":
+            return Round(subexpr)
 
 
 class Distributions:
@@ -136,9 +137,7 @@ class Distributions:
     def generate(dist_type: Identifier, lhs: Expr, expressions: List[Expr]):
         if dist_type.value == "normal":
             if len(expressions) != 2:
-                raise Exception(
-                    f"normal distribution needs 2 parameters, but got {len(expressions)}!"
-                )
+                raise Exception(f"normal distribution needs 2 parameters, but got {len(expressions)}!")
             return Normal(lhs, expressions[0], expressions[1])
 
 
@@ -148,7 +147,7 @@ class Parser:
         self.tokens = tokens
         self.data_names = data_names
 
-    def peek(self, k=0) -> Token:
+    def peek(self, k=0) -> Type[Token]:
         if k >= len(self.tokens):
             return NullToken()
         return self.tokens[k]
@@ -156,8 +155,8 @@ class Parser:
     def remove(self, index=0):
         self.tokens.pop(index)
 
-    def expect_token(self, token_type: Type[Token], token_value=None, remove=False):
-        next_token = self.peek()
+    def expect_token(self, token_type: Type[Token], token_value=None, remove=False, lookahead=0):
+        next_token = self.peek(lookahead)
         if not token_value:
             token_value = [next_token.value]
 
@@ -169,9 +168,7 @@ class Parser:
                 self.remove()
             return True
 
-        raise Exception(
-            f"Expected token type {token_type.__name__} with value in {token_value}, but received {next_token.__class__.__name__} with value '{next_token.value}'!"
-        )
+        raise Exception(f"Expected token type {token_type.__name__} with value in {token_value}, but received {next_token.__class__.__name__} with value '{next_token.value}'!")
 
     def expressions(self):
         expressions = []
@@ -204,12 +201,77 @@ class Parser:
             exp = IntegerConstant(int(token.value))
             self.remove()  # integer
 
-        if isinstance(token, Identifier):  # parameter/data
-            if token.value in self.data_names:
-                exp = Data(token.value)
-            else:
-                exp = Param(token.value)
-            self.remove()  # identifier
+        if isinstance(token, Identifier):  # parameter/data/function
+            if UnaryFunctions.check(token):    # unaryFunction '(' expression ')'
+                func_name = token
+                self.remove()  # functionName
+
+                self.expect_token(Special, "(")
+                self.remove()  # (
+                argument = self.expression()
+
+                self.expect_token(Special, ")")
+                self.remove()  # )
+                exp = UnaryFunctions.generate(argument, func_name)
+
+            else:  # parameter/data
+                if token.value in self.data_names:
+                    exp = Data(token.value)
+                    self.remove()  # identifier
+                else:
+                    exp = Param(token.value)
+                    self.remove()  # identifier
+
+                    # check for constraints  param<lower = 0.0, upper = 1.0>
+                    # 3-token lookahead: "<" + "lower" or "upper"
+                    lookahead_1 = self.peek()  # <
+                    lookahead_2 = self.peek(1)  # lower, upper
+                    if lookahead_1.value == "<" and lookahead_2.value in ("lower", "upper"):
+                        self.remove()  # <
+                        # the problem is that ">" is considered as an operator, but in the case of constraints, it is
+                        # not an operator, but a delimeter denoting the end of the constraint region.
+                        # Therefore, we need to find the matching ">" and change it from operator type to special, so
+                        # the expression parser does not think of it as a "greater than" operator. This goes away from
+                        # the ll(k) approach and therefore is a very hacky way to fix the issue.
+                        n_openbrackets = 0
+                        for idx in range(len(self.tokens)):
+                            if self.peek(idx).value == "<":
+                                n_openbrackets += 1
+                            if self.peek(idx).value == ">":
+                                if n_openbrackets == 0:
+                                    self.tokens[idx] = Special(">")  # switch from Operator to Special
+                                    break
+                                else:
+                                    n_openbrackets -= 1
+                        # now actually parse the constraints
+                        lower = RealConstant(float("-inf"))
+                        upper = RealConstant(float("inf"))
+                        for _ in range(2):  # loop at max 2 times, once for lower, once for upper
+                            if lookahead_2.value == "lower":
+                                self.remove()  # "lower"
+                                self.expect_token(Operator, token_value="=")
+                                self.remove()  # =
+                                lower = self.expression()
+                            elif lookahead_2.value == "upper":
+                                self.remove()  # "upper"
+                                self.expect_token(Operator, token_value="=")
+                                self.remove()  # =
+                                upper = self.expression()
+
+                            lookahead_1 = self.peek()  # can be either ",", which means loop again, or ">", which breaks
+                            lookahead_2 = self.peek(1)  # either "lower", or "upper" if lookahead_1 == ","
+                            if lookahead_1.value == ",":
+                                self.remove()  # ,
+                            elif lookahead_1.value == ">":
+                                self.remove()  # >
+                                break
+                            else:
+                                raise Exception(f"Found unknown token with value {lookahead_1.value} when evaluating constraints")
+
+                        # the for loop takes of the portion "<lower= ... >
+                        # this means the constraint part of been processed and removed from the token queue at this point
+                        exp.lower = lower
+                        exp.upper = upper
 
         if PrefixOps.check(token):  # prefixOp expression
             self.expect_token(Operator, PrefixOps.ops)  # operator
@@ -225,16 +287,10 @@ class Parser:
             self.remove()  # )
             exp = next_expression  # expression
 
-        next_token = (
-            self.peek()
-        )  # this is for the following 2 rules, which have conditions after expression
-        if (
-            isinstance(next_token, Special) and next_token.value == "["
-        ):  # identifier '[' expressions ']'
+        next_token = self.peek()  # this is for the following 2 rules, which have conditions after expression
+        if isinstance(next_token, Special) and next_token.value == "[":  # identifier '[' expressions ']'
             self.remove()  # [
-            warnings.warn(
-                "Parser: Indices are assumed to be a single literal, not expression."
-            )
+            warnings.warn("Parser: Indices are assumed to be a single literal, not expression.")
             expressions = self.expressions()  # list of expression
             self.expect_token(Special, "]")
             self.remove()  # ]
@@ -254,23 +310,20 @@ class Parser:
 
     def statement(self):
         token = self.peek()
-        if DefaultFunctions.check(token):
-            raise Exception("Cannot assign to a function name.")
         if Distributions.check(token):
             raise Exception("Cannot assign to a distribution.")
 
         # Step 1. evaluate lhs, assume it's expression
         lhs = self.expression()
-        if isinstance(lhs, Param) or isinstance(lhs, Data):
+        #if isinstance(lhs, Param) or isinstance(lhs, Data):
+        if isinstance(lhs, Expr):
             op = self.peek()
             if AssignmentOps.check(op):
                 self.remove()  # assignment operator
                 rhs = self.expression()
                 return AssignmentOps.generate(lhs, op, rhs)
 
-            elif (
-                isinstance(op, Special) and op.value == "~"
-            ):  # distribution declaration
+            elif isinstance(op, Special) and op.value == "~":  # distribution declaration
                 self.expect_token(Special, "~")
                 self.remove()  # ~
                 distribution = self.peek()
@@ -286,33 +339,3 @@ class Parser:
                 raise Exception("Statement finished without assignment")
 
         return Expr()
-
-
-if __name__ == "__main__":
-    from scanner import scanner
-
-    teststr = """
-score_diff~normal(skills[home_team, year]-skills[away_team, year],sigma);
-skills[team, year] ~ normal(skills_mu[year], tau);
-tau += -10;
-rob = 500;
-sigma ~ normal(0.0, -10.0);"""
-
-    # teststr = "tau += -1"
-
-    data_names = [
-        "game_id",
-        "date",
-        "home_score",
-        "away_score",
-        "home_team",
-        "away_team",
-    ]
-    for line in teststr.split("\n"):
-        if not line:
-            continue
-        print("-" * 10)
-        print(line)
-        print(list(x.value for x in scanner(line)))
-        # print(Parser(scanner(line)).statement().code() + ";")
-        print(Parser(scanner(line), data_names).statement())

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -10,11 +10,19 @@ def test_parser_multiple():
     tau<lower=0.0 + 5.0> ~ normal(0.0, 1.0);
     sigma<lower=0.0> ~ normal(0.0, 10.0);
     """
-    data_names = ["game_id", "date", "home_score", "away_score", "home_team", "away_team"]
+    data_names = [
+        "game_id",
+        "date",
+        "home_score",
+        "away_score",
+        "home_team",
+        "away_team",
+    ]
     print()
     for line in input_str.split("\n"):
         line = line.lstrip().rstrip()
-        if not line: continue
+        if not line:
+            continue
         print(f"running for line [{line}]")
         print(Parser(scanner(line), data_names).statement())
 
@@ -24,11 +32,18 @@ def test_parser_simple_constraint_sampling():
     data_names = []
     statement = Parser(scanner(input_str), data_names).statement()
     print(statement)
-    assert statement.__str__() == "Normal(Param(tau, None, lower=RealConstant(0.0), upper=RealConstant(inf)), RealConstant(0.0), RealConstant(1.0))"
+    assert (
+        statement.__str__()
+        == "Normal(Param(tau, None, lower=RealConstant(0.0), upper=RealConstant(inf)), RealConstant(0.0), RealConstant(1.0))"
+    )
+
 
 def test_parser_complex_constraint_sampling():
     input_str = "tau<lower=exp(0.0) ^ 1> ~ normal(0.0, 1.0);"
     data_names = []
     statement = Parser(scanner(input_str), data_names).statement()
     print(statement)
-    assert statement.__str__() == "Normal(Param(tau, None, lower=Pow(Exp(RealConstant(0.0)), IntegerConstant(1)), upper=RealConstant(inf)), RealConstant(0.0), RealConstant(1.0))"
+    assert (
+        statement.__str__()
+        == "Normal(Param(tau, None, lower=Pow(Exp(RealConstant(0.0)), IntegerConstant(1)), upper=RealConstant(inf)), RealConstant(0.0), RealConstant(1.0))"
+    )

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -1,5 +1,34 @@
 import pytest
+from rat.parser import Parser
+from rat.scanner import scanner
 
 
-def test_something_quick():
-    pass
+def test_parser_multiple():
+    input_str = """
+    score_diff~normal(skills[home_team, year]-skills[away_team, year],sigma);
+    skills[team, year] ~ normal(skills_mu[year], tau);
+    tau<lower=0.0 + 5.0> ~ normal(0.0, 1.0);
+    sigma<lower=0.0> ~ normal(0.0, 10.0);
+    """
+    data_names = ["game_id", "date", "home_score", "away_score", "home_team", "away_team"]
+    print()
+    for line in input_str.split("\n"):
+        line = line.lstrip().rstrip()
+        if not line: continue
+        print(f"running for line [{line}]")
+        print(Parser(scanner(line), data_names).statement())
+
+
+def test_parser_simple_constraint_sampling():
+    input_str = "tau<lower=0.0> ~ normal(0.0, 1.0);"
+    data_names = []
+    statement = Parser(scanner(input_str), data_names).statement()
+    print(statement)
+    assert statement.__str__() == "Normal(Param(tau, None, lower=RealConstant(0.0), upper=RealConstant(inf)), RealConstant(0.0), RealConstant(1.0))"
+
+def test_parser_complex_constraint_sampling():
+    input_str = "tau<lower=exp(0.0) ^ 1> ~ normal(0.0, 1.0);"
+    data_names = []
+    statement = Parser(scanner(input_str), data_names).statement()
+    print(statement)
+    assert statement.__str__() == "Normal(Param(tau, None, lower=Pow(Exp(RealConstant(0.0)), IntegerConstant(1)), upper=RealConstant(inf)), RealConstant(0.0), RealConstant(1.0))"


### PR DESCRIPTION
Looks like pytest works great! Parser can now handle `lower` and `upper` constraints specified after variable declaration. And not just fixed constants, but complete expressions.
Also added 5 unary functions to the parser/ops (exp, abs, floor, ceil, round) as well as the infix power operator(`^`).