### PR TITLE
Multi chain benchmarks (don't merge yet)

### DIFF
--- a/tests/multiple_gradient_benchmark.py
+++ b/tests/multiple_gradient_benchmark.py
@@ -1,0 +1,134 @@
+import jax
+import jax.numpy
+import numpy
+import scipy.special
+import scipy.stats
+import time
+
+
+N = int(1e6)
+M1 = int(1e4)
+M2 = int(1e3)
+
+group1 = numpy.random.randint(low = 0, high = M1, size = N)
+group2 = numpy.random.randint(low = 0, high = M2, size = N)
+
+theta1 = numpy.random.rand(M1)
+theta2 = numpy.random.rand(M2)
+
+prob = scipy.special.expit(theta1[group1] + theta2[group2])
+
+y = scipy.stats.bernoulli.rvs(prob)
+
+#print(y)
+#print(y.dtype)
+
+def target(y, group1, group2, theta1, theta2):
+    p = jax.scipy.special.expit(theta1[group1] + theta2[group2])
+    return jax.scipy.stats.bernoulli.logpmf(y, p)
+
+def target_vec_params(y, group1, group2, theta1, theta2):
+    return jax.vmap(target, (None, None, None, 0, 0))(y, group1, group2, theta1, theta2)
+
+def target_vec_data_vec_params(y, group1, group2, theta1, theta2):
+    return jax.vmap(target_vec_params, (0, 0, 0, None, None))(y, group1, group2, theta1, theta2)
+
+def target_vec_data(y, group1, group2, theta1, theta2):
+    return jax.vmap(target, (0, 0, 0, None, None))(y, group1, group2, theta1, theta2)
+
+def target_vec_params_vec_data(y, group1, group2, theta1, theta2):
+    return jax.vmap(target_vec_data, (None, None, None, 0, 0))(y, group1, group2, theta1, theta2)
+
+def single_chain_target(y, group1, group2, theta1, theta2):
+    return -jax.numpy.sum(target_vec_data(y, group1, group2, theta1, theta2))
+
+def multiple_chain_target(y, group1, group2, theta1, theta2):
+    return -jax.numpy.sum(target_vec_data_vec_params(y, group1, group2, theta1, theta2))
+
+def alternate_multiple_chain_target(y, group1, group2, theta1, theta2):
+    return -jax.numpy.sum(target_vec_params_vec_data(y, group1, group2, theta1, theta2))
+
+single_chain_grad = jax.jit(jax.grad(jax.jit(single_chain_target), argnums = (3, 4)))
+multiple_chain_grad = jax.jit(jax.grad(jax.jit(multiple_chain_target), argnums = (3, 4)))
+alternate_multiple_chain_grad = jax.jit(jax.grad(jax.jit(alternate_multiple_chain_target), argnums = (3, 4)))
+
+def parallel_single_chain_grad(y, group1, group2, theta1, theta2):
+    pmapped = jax.pmap(single_chain_grad, in_axes=(0, 0, 0, None, None))
+    return tuple(jax.numpy.sum(array, axis = 0) for array in pmapped(y, group1, group2, theta1, theta2))
+
+def parallel_multiple_chain_grad(y, group1, group2, theta1, theta2):
+    pmapped = jax.pmap(multiple_chain_grad, in_axes=(0, 0, 0, None, None))
+    return tuple(jax.numpy.sum(array, axis = 0) for array in pmapped(y, group1, group2, theta1, theta2))
+
+def parallel_alternate_multiple_chain_grad(y, group1, group2, theta1, theta2):
+    pmapped = jax.pmap(alternate_multiple_chain_grad, in_axes=(0, 0, 0, None, None))
+    return tuple(jax.numpy.sum(array, axis = 0) for array in pmapped(y, group1, group2, theta1, theta2))
+
+def benchmark(chains = 1, devices = 1, n_warmup = 100, n_time = 100):
+    print(f"Benchmarking {chains} chains on {devices} devices")
+    base_theta1 = jax.device_put(theta1)
+    base_theta2 = jax.device_put(theta2)
+    stacked_theta1 = jax.device_put(numpy.vstack(chains * [theta1]))
+    stacked_theta2 = jax.device_put(numpy.vstack(chains * [theta2]))
+
+    if devices == 1:
+        local_y = y
+        local_group1 = group1
+        local_group2 = group2
+
+        which_single_chain_grad = single_chain_grad
+        which_multiple_chain_grad = multiple_chain_grad
+        which_alternate_multiple_chain_grad = alternate_multiple_chain_grad
+    else:
+        local_y = numpy.reshape(y, (devices, -1))
+        local_group1 = numpy.reshape(group1, (devices, -1))
+        local_group2 = numpy.reshape(group2, (devices, -1))
+
+        which_single_chain_grad = parallel_single_chain_grad
+        which_multiple_chain_grad = parallel_multiple_chain_grad
+        which_alternate_multiple_chain_grad = parallel_alternate_multiple_chain_grad
+
+    device_y = jax.device_put(local_y)
+    device_group1 = jax.device_put(local_group1)
+    device_group2 = jax.device_put(local_group2)
+
+    # Do a few gradients to warm up
+    for i in range(100):
+        gradients_base = which_single_chain_grad(device_y, device_group1, device_group2, base_theta1, base_theta2)
+        gradients_stacked = which_multiple_chain_grad(device_y, device_group1, device_group2, stacked_theta1, stacked_theta2)
+        gradients_alternate_stacked = which_alternate_multiple_chain_grad(device_y, device_group1, device_group2, stacked_theta1, stacked_theta2)
+
+    # Check all the gradients match
+    for g1, g2, g3 in zip(gradients_base, gradients_stacked, gradients_alternate_stacked):
+        for j in range(chains):
+            assert numpy.allclose(g1, g2[j], atol = 1e-5)
+            assert numpy.allclose(g2[j], g3[j], atol = 1e-5)
+
+    # Benchmark the stacked version
+    start = time.time()
+    for i in range(n_time):
+        which_multiple_chain_grad(device_y, device_group1, device_group2, stacked_theta1, stacked_theta2)
+    print(f"{(time.time() - start) / n_time}s per gradient stacked (vectorize chains then data)")
+
+    # Benchmark the alternate stacked version
+    start = time.time()
+    for i in range(n_time):
+        which_alternate_multiple_chain_grad(device_y, device_group1, device_group2, stacked_theta1, stacked_theta2)
+    print(f"{(time.time() - start) / n_time}s per gradient alternate stacked (vectorize data then chains)")
+
+    # Benchmark the base version
+    start = time.time()
+    for i in range(n_time):
+        for j in range(chains):
+            which_single_chain_grad(device_y, device_group1, device_group2, base_theta1, base_theta2)
+    print(f"{(time.time() - start) / n_time}s per gradient looped (vectorize only data)")
+
+benchmark(chains = 1, devices = 1)
+benchmark(chains = 1, devices = 2)
+benchmark(chains = 1, devices = 4)
+benchmark(chains = 2, devices = 1)
+benchmark(chains = 2, devices = 2)
+benchmark(chains = 2, devices = 4)
+benchmark(chains = 4, devices = 1)
+benchmark(chains = 4, devices = 2)
+benchmark(chains = 4, devices = 4)

--- a/tests/multiple_gradient_benchmark.py
+++ b/tests/multiple_gradient_benchmark.py
@@ -10,8 +10,8 @@ N = int(1e6)
 M1 = int(1e4)
 M2 = int(1e3)
 
-group1 = numpy.random.randint(low = 0, high = M1, size = N)
-group2 = numpy.random.randint(low = 0, high = M2, size = N)
+group1 = numpy.random.randint(low=0, high=M1, size=N)
+group2 = numpy.random.randint(low=0, high=M2, size=N)
 
 theta1 = numpy.random.rand(M1)
 theta2 = numpy.random.rand(M2)
@@ -20,51 +20,79 @@ prob = scipy.special.expit(theta1[group1] + theta2[group2])
 
 y = scipy.stats.bernoulli.rvs(prob)
 
-#print(y)
-#print(y.dtype)
+# print(y)
+# print(y.dtype)
+
 
 def target(y, group1, group2, theta1, theta2):
     p = jax.scipy.special.expit(theta1[group1] + theta2[group2])
     return jax.scipy.stats.bernoulli.logpmf(y, p)
 
+
 def target_vec_params(y, group1, group2, theta1, theta2):
     return jax.vmap(target, (None, None, None, 0, 0))(y, group1, group2, theta1, theta2)
 
+
 def target_vec_data_vec_params(y, group1, group2, theta1, theta2):
-    return jax.vmap(target_vec_params, (0, 0, 0, None, None))(y, group1, group2, theta1, theta2)
+    return jax.vmap(target_vec_params, (0, 0, 0, None, None))(
+        y, group1, group2, theta1, theta2
+    )
+
 
 def target_vec_data(y, group1, group2, theta1, theta2):
     return jax.vmap(target, (0, 0, 0, None, None))(y, group1, group2, theta1, theta2)
 
+
 def target_vec_params_vec_data(y, group1, group2, theta1, theta2):
-    return jax.vmap(target_vec_data, (None, None, None, 0, 0))(y, group1, group2, theta1, theta2)
+    return jax.vmap(target_vec_data, (None, None, None, 0, 0))(
+        y, group1, group2, theta1, theta2
+    )
+
 
 def single_chain_target(y, group1, group2, theta1, theta2):
     return -jax.numpy.sum(target_vec_data(y, group1, group2, theta1, theta2))
 
+
 def multiple_chain_target(y, group1, group2, theta1, theta2):
     return -jax.numpy.sum(target_vec_data_vec_params(y, group1, group2, theta1, theta2))
+
 
 def alternate_multiple_chain_target(y, group1, group2, theta1, theta2):
     return -jax.numpy.sum(target_vec_params_vec_data(y, group1, group2, theta1, theta2))
 
-single_chain_grad = jax.jit(jax.grad(jax.jit(single_chain_target), argnums = (3, 4)))
-multiple_chain_grad = jax.jit(jax.grad(jax.jit(multiple_chain_target), argnums = (3, 4)))
-alternate_multiple_chain_grad = jax.jit(jax.grad(jax.jit(alternate_multiple_chain_target), argnums = (3, 4)))
+
+single_chain_grad = jax.jit(jax.grad(jax.jit(single_chain_target), argnums=(3, 4)))
+multiple_chain_grad = jax.jit(jax.grad(jax.jit(multiple_chain_target), argnums=(3, 4)))
+alternate_multiple_chain_grad = jax.jit(
+    jax.grad(jax.jit(alternate_multiple_chain_target), argnums=(3, 4))
+)
+
 
 def parallel_single_chain_grad(y, group1, group2, theta1, theta2):
     pmapped = jax.pmap(single_chain_grad, in_axes=(0, 0, 0, None, None))
-    return tuple(jax.numpy.sum(array, axis = 0) for array in pmapped(y, group1, group2, theta1, theta2))
+    return tuple(
+        jax.numpy.sum(array, axis=0)
+        for array in pmapped(y, group1, group2, theta1, theta2)
+    )
+
 
 def parallel_multiple_chain_grad(y, group1, group2, theta1, theta2):
     pmapped = jax.pmap(multiple_chain_grad, in_axes=(0, 0, 0, None, None))
-    return tuple(jax.numpy.sum(array, axis = 0) for array in pmapped(y, group1, group2, theta1, theta2))
+    return tuple(
+        jax.numpy.sum(array, axis=0)
+        for array in pmapped(y, group1, group2, theta1, theta2)
+    )
+
 
 def parallel_alternate_multiple_chain_grad(y, group1, group2, theta1, theta2):
     pmapped = jax.pmap(alternate_multiple_chain_grad, in_axes=(0, 0, 0, None, None))
-    return tuple(jax.numpy.sum(array, axis = 0) for array in pmapped(y, group1, group2, theta1, theta2))
+    return tuple(
+        jax.numpy.sum(array, axis=0)
+        for array in pmapped(y, group1, group2, theta1, theta2)
+    )
 
-def benchmark(chains = 1, devices = 1, n_warmup = 100, n_time = 100):
+
+def benchmark(chains=1, devices=1, n_warmup=100, n_time=100):
     print(f"Benchmarking {chains} chains on {devices} devices")
     base_theta1 = jax.device_put(theta1)
     base_theta2 = jax.device_put(theta2)
@@ -94,41 +122,62 @@ def benchmark(chains = 1, devices = 1, n_warmup = 100, n_time = 100):
 
     # Do a few gradients to warm up
     for i in range(100):
-        gradients_base = which_single_chain_grad(device_y, device_group1, device_group2, base_theta1, base_theta2)
-        gradients_stacked = which_multiple_chain_grad(device_y, device_group1, device_group2, stacked_theta1, stacked_theta2)
-        gradients_alternate_stacked = which_alternate_multiple_chain_grad(device_y, device_group1, device_group2, stacked_theta1, stacked_theta2)
+        gradients_base = which_single_chain_grad(
+            device_y, device_group1, device_group2, base_theta1, base_theta2
+        )
+        gradients_stacked = which_multiple_chain_grad(
+            device_y, device_group1, device_group2, stacked_theta1, stacked_theta2
+        )
+        gradients_alternate_stacked = which_alternate_multiple_chain_grad(
+            device_y, device_group1, device_group2, stacked_theta1, stacked_theta2
+        )
 
     # Check all the gradients match
-    for g1, g2, g3 in zip(gradients_base, gradients_stacked, gradients_alternate_stacked):
+    for g1, g2, g3 in zip(
+        gradients_base, gradients_stacked, gradients_alternate_stacked
+    ):
         for j in range(chains):
-            assert numpy.allclose(g1, g2[j], atol = 1e-5)
-            assert numpy.allclose(g2[j], g3[j], atol = 1e-5)
+            assert numpy.allclose(g1, g2[j], atol=1e-5)
+            assert numpy.allclose(g2[j], g3[j], atol=1e-5)
 
     # Benchmark the stacked version
     start = time.time()
     for i in range(n_time):
-        which_multiple_chain_grad(device_y, device_group1, device_group2, stacked_theta1, stacked_theta2)
-    print(f"{(time.time() - start) / n_time}s per gradient stacked (vectorize chains then data)")
+        which_multiple_chain_grad(
+            device_y, device_group1, device_group2, stacked_theta1, stacked_theta2
+        )
+    print(
+        f"{(time.time() - start) / n_time}s per gradient stacked (vectorize chains then data)"
+    )
 
     # Benchmark the alternate stacked version
     start = time.time()
     for i in range(n_time):
-        which_alternate_multiple_chain_grad(device_y, device_group1, device_group2, stacked_theta1, stacked_theta2)
-    print(f"{(time.time() - start) / n_time}s per gradient alternate stacked (vectorize data then chains)")
+        which_alternate_multiple_chain_grad(
+            device_y, device_group1, device_group2, stacked_theta1, stacked_theta2
+        )
+    print(
+        f"{(time.time() - start) / n_time}s per gradient alternate stacked (vectorize data then chains)"
+    )
 
     # Benchmark the base version
     start = time.time()
     for i in range(n_time):
         for j in range(chains):
-            which_single_chain_grad(device_y, device_group1, device_group2, base_theta1, base_theta2)
-    print(f"{(time.time() - start) / n_time}s per gradient looped (vectorize only data)")
+            which_single_chain_grad(
+                device_y, device_group1, device_group2, base_theta1, base_theta2
+            )
+    print(
+        f"{(time.time() - start) / n_time}s per gradient looped (vectorize only data)"
+    )
 
-benchmark(chains = 1, devices = 1)
-benchmark(chains = 1, devices = 2)
-benchmark(chains = 1, devices = 4)
-benchmark(chains = 2, devices = 1)
-benchmark(chains = 2, devices = 2)
-benchmark(chains = 2, devices = 4)
-benchmark(chains = 4, devices = 1)
-benchmark(chains = 4, devices = 2)
-benchmark(chains = 4, devices = 4)
+
+benchmark(chains=1, devices=1)
+benchmark(chains=1, devices=2)
+benchmark(chains=1, devices=4)
+benchmark(chains=2, devices=1)
+benchmark(chains=2, devices=2)
+benchmark(chains=2, devices=4)
+benchmark(chains=4, devices=1)
+benchmark(chains=4, devices=2)
+benchmark(chains=4, devices=4)


### PR DESCRIPTION
Here's the benchmarks running on my laptop (4 cores so 4 jax devices once I did [this](https://github.com/google/jax/issues/1408), and I assume one memory channel).

The tldr; I'm getting is we can get gradients for multiple chains if we lump them together than if we do them separately (this comes from efficiency on the data arguments).

Running multiple cores didn't seem to give me much speedup, so I assume my laptop has only one memory channel and it's saturated by just a single core.

```
$ python multiple_gradient_benchmark.py 
Benchmarking 1 chains on 1 devices
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
0.0054526662826538085s per gradient stacked (vectorize chains then data)
0.005476508140563965s per gradient alternate stacked (vectorize data then chains)
0.005332326889038086s per gradient looped (vectorize only data)
Benchmarking 1 chains on 2 devices
0.00569195032119751s per gradient stacked (vectorize chains then data)
0.005628719329833985s per gradient alternate stacked (vectorize data then chains)
0.005674223899841308s per gradient looped (vectorize only data)
Benchmarking 1 chains on 4 devices
0.011375186443328857s per gradient stacked (vectorize chains then data)
0.009662230014801026s per gradient alternate stacked (vectorize data then chains)
0.008864026069641113s per gradient looped (vectorize only data)
Benchmarking 2 chains on 1 devices
0.00956094741821289s per gradient stacked (vectorize chains then data)
0.007661082744598389s per gradient alternate stacked (vectorize data then chains)
0.010693693161010742s per gradient looped (vectorize only data)
Benchmarking 2 chains on 2 devices
0.011032798290252686s per gradient stacked (vectorize chains then data)
0.007630512714385986s per gradient alternate stacked (vectorize data then chains)
0.011031227111816406s per gradient looped (vectorize only data)
Benchmarking 2 chains on 4 devices
0.008817522525787354s per gradient stacked (vectorize chains then data)
0.008090007305145263s per gradient alternate stacked (vectorize data then chains)
0.019619812965393068s per gradient looped (vectorize only data)
Benchmarking 4 chains on 1 devices
0.014279656410217285s per gradient stacked (vectorize chains then data)
0.013145151138305665s per gradient alternate stacked (vectorize data then chains)
0.021440510749816896s per gradient looped (vectorize only data)
Benchmarking 4 chains on 2 devices
0.01370650053024292s per gradient stacked (vectorize chains then data)
0.01083871841430664s per gradient alternate stacked (vectorize data then chains)
0.022269191741943358s per gradient looped (vectorize only data)
Benchmarking 4 chains on 4 devices
0.01262789249420166s per gradient stacked (vectorize chains then data)
0.008902204036712647s per gradient alternate stacked (vectorize data then chains)
0.034102864265441894s per gradient looped (vectorize only data)
```