### PR TITLE
Update parser and ops.Index to support union() in subscripts

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -88,6 +88,7 @@ expressions ::= expression % ','
 ; subscript formats, which define dimensions and indexing of parameters/data
 subscript_expressions ::= identifier % ','
                         | shift(identifier, integer) % ','
+                        | union(identifier % ',')
 
 ; binary operations, just arithmetic and logical
 infixOps ::= ("+", "-", "*", "/", "%",

--- a/rat/ops.py
+++ b/rat/ops.py
@@ -42,7 +42,8 @@ class IntegerConstant(Expr):
 
 @dataclass
 class Index(Expr):
-    names: Tuple[str]
+    names: Tuple[str, Tuple[str]]
+    """string denotes single column. a nested tuple inside means union of columns in the nested tuple"""
     shifts: Tuple[Union[str, None]] = (None,)
     variable: variables.Index = None
 
@@ -53,12 +54,18 @@ class Index(Expr):
         return self.variable.code()
 
     def __str__(self):
-        return f"Index(names=({', '.join(x.__str__() for x in self.names)}), shift=({', '.join(x.__str__() for x in self.shifts)}))"
+        index_names = []
+        for x in self.names:
+            if isinstance(x, tuple):
+                index_names.append(f"union({','.join(x)})")
+            else:
+                index_names.append(x)
+        return f"Index(names=({', '.join(index_names)}), shift=({', '.join(x.__str__() for x in self.shifts)}))"
 
 
 @dataclass
 class Data(Expr):
-    name: str
+    name: Tuple[str] = (None, )
     index: Index = None
     variable: variables.Data = None
 

--- a/rat/ops.py
+++ b/rat/ops.py
@@ -65,7 +65,7 @@ class Index(Expr):
 
 @dataclass
 class Data(Expr):
-    name: Tuple[str] = (None, )
+    name: Tuple[str] = (None,)
     index: Index = None
     variable: variables.Data = None
 

--- a/rat/parser.py
+++ b/rat/parser.py
@@ -195,7 +195,7 @@ class Parser:
             f"Expected token types {[x.__name__ for x in token_types]} with value in {token_value}, but received {next_token.__class__.__name__} with value '{next_token.value}'!"
         )
 
-    def expressions(self, entry_token_value, allow_shift=False) -> Tuple[List[Expr], Tuple[int]]:
+    def expressions(self, entry_token_value, is_subscript=False) -> Tuple[List[Expr], Tuple[int]]:
         if entry_token_value == "[":
             exit_value = "]"
         elif entry_token_value == "(":
@@ -230,7 +230,7 @@ class Parser:
                     self.remove()  # character ,
                     continue
             elif isinstance(token, Identifier) and token.value == "shift":
-                if not allow_shift:
+                if not is_subscript:
                     raise Exception("shift() has been used in a position that is not allowed.")
                 # parse lag(index, integer)
                 self.remove()  # identifier "lag"
@@ -249,6 +249,20 @@ class Parser:
                 self.remove()  # shift integer
                 self.expect_token(Special, ")")
                 self.remove()  # character )
+            elif isinstance(token, Identifier) and token.value == "union":
+                if not is_subscript:
+                    raise Exception("union() has been used in a position that is not allowed.")
+                self.remove()  # identifier "union"
+                self.expect_token(Special, "(")
+                self.remove()  # special (
+                subscript_names, _ = self.expressions("(")
+                for name in subscript_names:
+                    assert isinstance(name, Data), "subscripts in shift() must be a data column"
+                    if name.name not in self.data_names:
+                        raise Exception("subscript specified with union() must be in data columns.")
+                expression = Data(tuple([s.name for s in subscript_names]))
+                self.expect_token(Special, ")")
+                self.remove()  # special )
             else:
                 expression = self.expression()
             expressions.append(expression)
@@ -367,7 +381,7 @@ class Parser:
             # identifier '[' subscript_expressions ']'
             self.remove()  # [
             warnings.warn("Parser: subscripts are assumed to be a single literal, not expression.")
-            expressions, shift_amount = self.expressions("[", allow_shift=True)  # list of expression
+            expressions, shift_amount = self.expressions("[", is_subscript=True)  # list of expression
             self.expect_token(Special, "]")
             self.remove()  # ]
             # Assume index is a single identifier - this is NOT GOOD

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -100,17 +100,15 @@ def test_parser_rhs_index_shift_multiple():
 
     assert statement.__str__() == expected.__str__()
 
+
 def test_parser_lhs_subscript_union():
     input_str = "tau<lower = 0.0>[union(home_team, away_team), year] ~ normal(0.0, 1.0);"
     data_names = ["home_team", "away_team", "year"]
     statement = Parser(scanner(input_str), data_names).statement()
 
     expected = Normal(
-        Param(name="tau",
-              index=Index((("home_team", "away_team"), "year"), shifts=(None, None)),
-              lower=RealConstant("0.0")),
-
+        Param(name="tau", index=Index((("home_team", "away_team"), "year"), shifts=(None, None)), lower=RealConstant("0.0")),
         RealConstant("0.0"),
-        RealConstant("1.0")
+        RealConstant("1.0"),
     )
     assert statement.__str__() == expected.__str__()

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -7,7 +7,7 @@ from rat.ops import *
 def test_parser_multiple():
     input_str = """
     score_diff~normal(skills[home_team, year]-skills[away_team, year],sigma);
-    skills[team, year] ~ normal(skills_mu[year], tau);
+    skills[union(home_team, away_team), year] ~ normal(skills_mu[year], tau);
     tau<lower=0.0 + 5.0> ~ normal(0.0, 1.0);
     sigma<lower=0.0> ~ normal(0.0, 10.0);
     """
@@ -98,4 +98,19 @@ def test_parser_rhs_index_shift_multiple():
         RealConstant(1.0),
     )
 
+    assert statement.__str__() == expected.__str__()
+
+def test_parser_lhs_subscript_union():
+    input_str = "tau<lower = 0.0>[union(home_team, away_team), year] ~ normal(0.0, 1.0);"
+    data_names = ["home_team", "away_team", "year"]
+    statement = Parser(scanner(input_str), data_names).statement()
+
+    expected = Normal(
+        Param(name="tau",
+              index=Index((("home_team", "away_team"), "year"), shifts=(None, None)),
+              lower=RealConstant("0.0")),
+
+        RealConstant("0.0"),
+        RealConstant("1.0")
+    )
     assert statement.__str__() == expected.__str__()


### PR DESCRIPTION
Now `Index.name` is a tuple of tuples or strings, with a nested tuple denoting union of its content.

```
tau<lower = 0.0>[union(home_team, away_team), year]
```
is the way to use it. However, 
```
tau[union(home_team, away_team), year]<lower = 0.0>
```
will not work.