### PR TITLE
Added test for bounded constraints

### DIFF
--- a/tests/integration/test_optimize.py
+++ b/tests/integration/test_optimize.py
@@ -47,6 +47,7 @@ def test_optimize_normal_mu_sigma():
     assert mu_df["mu"][0] == pytest.approx(-0.837757, rel=1e-2)
     assert sigma_df["sigma"][0] == pytest.approx(3.880730, rel=1e-2)
 
+
 def test_optimize_normal_mu_sigma_bounded():
     data_df = pandas.read_csv(os.path.join(test_dir, "normal.csv"))
 
@@ -64,7 +65,7 @@ def test_optimize_normal_mu_sigma_bounded():
     # With different constraints, we would get solutions
     # outside these bounds
     assert mu_df["mu"][0] >= 0.0
-    assert sigma_df["sigma"][0] <= 0.1 + 1e-7 # not sure how solution is slightly above, guess some precision thing?
+    assert sigma_df["sigma"][0] <= 0.1 + 1e-7  # not sure how solution is slightly above, guess some precision thing?
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_optimize.py
+++ b/tests/integration/test_optimize.py
@@ -47,7 +47,25 @@ def test_optimize_normal_mu_sigma():
     assert mu_df["mu"][0] == pytest.approx(-0.837757, rel=1e-2)
     assert sigma_df["sigma"][0] == pytest.approx(3.880730, rel=1e-2)
 
+def test_optimize_normal_mu_sigma_bounded():
+    data_df = pandas.read_csv(os.path.join(test_dir, "normal.csv"))
+
+    model_string = """
+    y ~ normal(mu, sigma);
+    mu<lower = 0.0> ~ normal(-0.5, 0.3);
+    sigma<lower = 0.0, upper = 0.1> ~ normal(0.0, 0.7);
+    """
+
+    model = Model(data_df, model_string=model_string)
+    fit = model.optimize(init=2.0)
+    mu_df = fit.draws("mu")
+    sigma_df = fit.draws("sigma")
+
+    # With different constraints, we would get solutions
+    # outside these bounds
+    assert mu_df["mu"][0] >= 0.0
+    assert sigma_df["sigma"][0] <= 0.1 + 1e-7 # not sure how solution is slightly above, guess some precision thing?
+
 
 if __name__ == "__main__":
-    logging.getLogger().setLevel(logging.DEBUG)
     pytest.main([__file__, "-s", "-o", "log_cli=true"])


### PR DESCRIPTION
The weird thing here is apparently the optimizer spits out as solution:

```
sigma_df["sigma"][0]
0.10000000149011612
```

We're doing single precision stuff here so those extra digits are reasonable, but I guess we lost precision somewhere and ended up over the bound? Oh well, something we should keep in mind.